### PR TITLE
Fix buf-setup-action config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,8 @@ jobs:
       # Install the `buf` CLI
       - name: Setup
         uses: bufbuild/buf-setup-action@v0.5.0
-        version: '1.1.0'
+        with:
+          version: '1.1.0'
       # Lint the Buf module in the `github-actions` directory
       - name: Lint
         uses: bufbuild/buf-lint-action@v1
@@ -18,7 +19,7 @@ jobs:
           input: github-actions
       # Detect breaking changes for the Buf module in the `github-actions` directory
       # against the current `main` branch
-      - name: Run breaking change detection against `main`
+      - name: Breaking change detection against `main`
         uses: bufbuild/buf-breaking-action@v1
         with:
           input: github-actions


### PR DESCRIPTION
A recent PR broke the GitHub Actions config. This PR gets things working again.
