### PR TITLE
Revert "CI/CD revamp follow-up"

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -5,7 +5,7 @@
 This example project shows you how to use Buf in a [CircleCI][circle] setting. The workflow here involves two steps:
 
 * [Linting][lint] the Protobuf module in the [`proto`](../proto) directory
-* Running [breaking change detection][breaking] against the `proto` module on the current `main` branch
+* Running [breaking change detection][breaking] against the current `main` branch
 
 The configuration for [CircleCI][circle] is in [`config.yml`](./config.yml).
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - image: bufbuild/buf:1.1.0
     steps:
       - checkout
-      - run: buf breaking proto --against https://github.com/bufbuild/buf-examples.git#branch=main,subdir=proto
+      - run: buf breaking proto --against https://github.com/bufbuild/buf-examples.git#branch=main,ref=HEAD~1,subdir=proto
 
 workflows:
   version: 2

--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,7 @@ This example project shows you how to use Buf in a [GitHub Actions][actions] set
 
 * [`buf-setup-action`][buf-setup] installs the [`buf` CLI][cli]
 * [`buf-lint-action`][buf-lint] [lints][lint] the Protobuf module in the [`proto`](../proto) directory
-* [`buf-breaking-action`][buf-breaking] runs [breaking change detection][breaking] against the `proto` module on the current `main` branch
+* [`buf-breaking-action`][buf-breaking] runs [breaking change detection][breaking] against the current `main` branch
 
 The configuration for [GitHub Actions][actions] is in [`workflows/ci.yaml`](./workflows/ci.yaml).
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,4 +23,4 @@ jobs:
         uses: bufbuild/buf-breaking-action@v1
         with:
           input: proto
-          against: https://github.com/bufbuild/buf-examples.git#branch=main,subdir=proto
+          against: https://github.com/bufbuild/buf-examples.git#branch=main,ref=HEAD~1,subdir=proto


### PR DESCRIPTION
Unfortunately, this CI/CD revamp needs to be reverted, as it turns out that you can't put a `README.md` into the `.github` directory. If you do, that implicitly becomes the main project README, which we don't want.