### PR TITLE
Fix version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Several of these projects available as modules on the [Buf Schema Registry][bsr]
 [modules]: https://docs.buf.build/bsr/overview#modules
 [plugin]: https://docs.buf.build/bsr/remote-generation/concepts#plugins
 [remote]: https://docs.buf.build/bsr/remote-generation/remote-plugin-execution
-[version]: https://github.com/bufbuild/buf/releases/tag/v1.5.0
+[version]: https://github.com/bufbuild/buf/releases/tag/v1.8.0
 [workspace]: https://docs.buf.build/reference/workspaces


### PR DESCRIPTION
Updated the version [here][1] but left the link to the older version; this syncs up the links.

[1]: https://github.com/bufbuild/buf-examples/commit/0fb2347d00df4f881d8d20a1b8d20d03a2be54a4#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7
