### PR TITLE
Update workspace example to compile and be usable

### DIFF
--- a/workspace/buf.gen.yaml
+++ b/workspace/buf.gen.yaml
@@ -2,11 +2,11 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: github.com/buf-examples/observability
+    default: github.com/bufbuild/buf-examples/workspace/gen/proto/go
 plugins:
   - plugin: buf.build/protocolbuffers/go:v1.28.1
+    opt: paths=source_relative
     out: gen/proto/go
-  - plugin: buf.build/protocolbuffers/java:v21.9
-    out: gen/proto/java
-  - plugin: buf.build/protocolbuffers/python:v21.9
-    out: gen/proto/python
+  - plugin: buf.build/bufbuild/connect-go:v1.7.0
+    opt: paths=source_relative
+    out: gen/proto/go

--- a/workspace/cmd/api1/api1.go
+++ b/workspace/cmd/api1/api1.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+
+	apiv1 "github.com/bufbuild/buf-examples/workspace/gen/proto/go/api/v1"
+	"github.com/bufbuild/buf-examples/workspace/gen/proto/go/api/v1/apiv1connect"
+	"github.com/bufbuild/connect-go"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+func main() {
+	const addr = "127.0.0.1:8080"
+
+	log.Printf("Observability service starting")
+
+	mux := http.NewServeMux()
+
+	path, handler := apiv1connect.NewObservabilityServiceHandler(&service{})
+	mux.Handle(path, handler)
+	log.Printf("Handling connect service at prefix: %v", path)
+
+	log.Printf("Listening on: %v", addr)
+	err := http.ListenAndServe(
+		addr,
+		h2c.NewHandler(mux, &http2.Server{}),
+	)
+
+	if err != http.ErrServerClosed {
+		log.Printf("Error running or stopping: %v", err)
+	}
+}
+
+type service struct {
+}
+
+func (s *service) GetLogs(
+	ctx context.Context,
+	req *connect.Request[apiv1.GetLogsRequest],
+) (
+	*connect.Response[apiv1.GetLogsResponse],
+	error,
+) {
+	return nil, errors.New("Needs impementation")
+}
+
+func (s *service) PutLogs(
+	ctx context.Context,
+	req *connect.Request[apiv1.PutLogsRequest],
+) (
+	*connect.Response[emptypb.Empty],
+	error,
+) {
+	return nil, errors.New("Needs implementation")
+}
+
+func (s *service) GetMetrics(
+	ctx context.Context,
+	req *connect.Request[apiv1.GetMetricsRequest],
+) (
+	*connect.Response[apiv1.GetMetricsResponse],
+	error,
+) {
+	return nil, errors.New("Needs implementation")
+}

--- a/workspace/cmd/api2/api2.go
+++ b/workspace/cmd/api2/api2.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+
+	apiv2 "github.com/bufbuild/buf-examples/workspace/gen/proto/go/api/v2"
+	"github.com/bufbuild/buf-examples/workspace/gen/proto/go/api/v2/apiv2connect"
+	"github.com/bufbuild/connect-go"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+var ErrorNeedsImplementation = errors.New("needs implementation")
+
+func main() {
+	const addr = "127.0.0.1:8080"
+
+	log.Printf("Observability service starting")
+
+	mux := http.NewServeMux()
+
+	path, handler := apiv2connect.NewObservabilityServiceHandler(&service{})
+	mux.Handle(path, handler)
+	log.Printf("Handling connect service at prefix: %v", path)
+
+	log.Printf("Listening on: %v", addr)
+	err := http.ListenAndServe(
+		addr,
+		h2c.NewHandler(mux, &http2.Server{}),
+	)
+
+	if err != http.ErrServerClosed {
+		log.Printf("Error running or stopping: %v", err)
+	}
+}
+
+type service struct{}
+
+func (s *service) GetLogs(
+	ctx context.Context,
+	req *connect.Request[apiv2.GetLogsRequest],
+) (
+	*connect.Response[apiv2.GetLogsResponse],
+	error,
+) {
+	return nil, ErrorNeedsImplementation
+}
+
+func (s *service) PutLogs(
+	ctx context.Context,
+	req *connect.Request[apiv2.PutLogsRequest],
+) (
+	*connect.Response[emptypb.Empty],
+	error,
+) {
+	return nil, ErrorNeedsImplementation
+}
+
+func (s *service) GetMetrics(
+	ctx context.Context,
+	req *connect.Request[apiv2.GetMetricsRequest],
+) (
+	*connect.Response[apiv2.GetMetricsResponse],
+	error,
+) {
+	return nil, ErrorNeedsImplementation
+}

--- a/workspace/go.mod
+++ b/workspace/go.mod
@@ -1,0 +1,11 @@
+module github.com/bufbuild/buf-examples/workspace
+
+go 1.20
+
+require (
+	github.com/bufbuild/connect-go v1.7.0
+	golang.org/x/net v0.10.0
+	google.golang.org/protobuf v1.30.0
+)
+
+require golang.org/x/text v0.9.0 // indirect

--- a/workspace/go.sum
+++ b/workspace/go.sum
@@ -1,0 +1,13 @@
+github.com/bufbuild/connect-go v1.7.0 h1:MGp82v7SCza+3RhsVhV7aMikwxvI3ZfD72YiGt8FYJo=
+github.com/bufbuild/connect-go v1.7.0/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=


### PR DESCRIPTION
A user on Buf public slack tried out the workspace example, however prior to this PR the example generates code but fails on imports when examining the generated code.

This PR updates the workspace example with a working minimal Go service that uses the generated code from the workspace. The imports work correctly using `go mod tidy` and readers can run the example with `go run`.

This should be less confusing to users, and allows them to continue working out the example for their own needs if they wish to do that.