### PR TITLE
Add protovalidate to the buf examples root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ This repository houses example projects and code for products in the [Buf][buf] 
 
 [A quickstart guide](bsr) for the [Buf Schema Registry (BSR)][bsr] demonstrates how the BSR manages schemas, dependencies, and governance at scale.
 
+## Protovalidate
+
+[Quickstart guides and examples](protovalidate) for [Protovalidate][protovalidate] show how standard annotations and custom CEL expressions can be used to validate Protobuf messages.
+
 ## Integrations
 
 [Integrations](integrations) contains example code supporting Buf's documentation regarding integration with CI/CD pipelines.
 
 [buf]: https://buf.build
 [bsr]: https://buf.build/docs/bsr/
+[protovalidate]: https://buf.build/docs/protovalidate/
 [cli-documentation]: https://buf.build/docs/cli/
 [docs]: https://buf.build/docs

--- a/protovalidate/README.md
+++ b/protovalidate/README.md
@@ -52,11 +52,11 @@ Quickstart code showing how to use Protovalidate in unary RPCs is available in t
 [predefined-rules]: https://buf.build/docs/protovalidate/schemas/predefined-rules/
 [standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
 [custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
-[connect-go]: https://buf.build/docs/protovalidate/how-to/connect-go
-[grpc-go]: https://buf.build/docs/protovalidate/how-to/grpc-go
-[grpc-java]: https://buf.build/docs/protovalidate/how-to/grpc-java
-[grpc-python]: https://buf.build/docs/protovalidate/how-to/grpc-python
-[bufstream]: https://buf.build/docs/protovalidate/how-to/bufstream
+[connect-go]: https://buf.build/docs/protovalidate/quickstart/connect-go
+[grpc-go]: https://buf.build/docs/protovalidate/quickstart/grpc-go
+[grpc-java]: https://buf.build/docs/protovalidate/quickstart/grpc-java
+[grpc-python]: https://buf.build/docs/protovalidate/quickstart/grpc-python
+[bufstream]: https://buf.build/docs/protovalidate/quickstart/bufstream
 
 [protoc-gen-validate]: https://github.com/bufbuild/protoc-gen-validate
 [yup]: https://github.com/jquense/yup

--- a/protovalidate/bufstream/README.md
+++ b/protovalidate/bufstream/README.md
@@ -11,4 +11,4 @@ This directory contains companion code for the [using Protovalidate in Kafka wit
 
 Its `start` directory is the starting state for code exercise, and `finish` contains a working solution.
 
-[documentation]: https://buf.build/docs/protovalidate/how-to/bufstream
+[documentation]: https://buf.build/docs/protovalidate/quickstart/bufstream

--- a/protovalidate/connect-go/README.md
+++ b/protovalidate/connect-go/README.md
@@ -11,4 +11,4 @@ This directory contains companion code for [the Protovalidate in Connect and Go 
 
 Its `start` directory is the starting state for code exercise, and `finish` contains a working solution.
 
-[documentation]: https://buf.build/docs/protovalidate/how-to/connect-go/
+[documentation]: https://buf.build/docs/protovalidate/quickstart/connect-go/

--- a/protovalidate/grpc-go/README.md
+++ b/protovalidate/grpc-go/README.md
@@ -11,4 +11,4 @@ This directory contains companion code for [the Protovalidate in gRPC and Go qui
 
 Its `start` directory is the starting state for code exercise, and `finish` contains a working solution.
 
-[documentation]: https://buf.build/docs/protovalidate/how-to/grpc-go/
+[documentation]: https://buf.build/docs/protovalidate/quickstart/grpc-go/

--- a/protovalidate/grpc-java/README.md
+++ b/protovalidate/grpc-java/README.md
@@ -11,4 +11,4 @@ This directory contains companion code for [the Protovalidate in gRPC and Java q
 
 Its `start` directory is the starting state for code exercise, and `finish` contains a working solution.
 
-[documentation]: https://buf.build/docs/protovalidate/how-to/grpc-java/
+[documentation]: https://buf.build/docs/protovalidate/quickstart/grpc-java/

--- a/protovalidate/grpc-python/README.md
+++ b/protovalidate/grpc-python/README.md
@@ -11,4 +11,4 @@ This directory contains companion code for [the Protovalidate in gRPC and Python
 
 Its `start` directory is the starting state for code exercise, and `finish` contains a working solution.
 
-[documentation]: https://buf.build/docs/protovalidate/how-to/grpc-python/
+[documentation]: https://buf.build/docs/protovalidate/quickstart/grpc-python/


### PR DESCRIPTION
This PR adds Protovalidate to the root README and updates the `how-to` links to be `quickstart`.