### PR TITLE
Replace flags with equivalent environment vars

### DIFF
--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   # Iceberg catalog for archival. Additional configuration is in
   # config/bufstream.yaml.
   bufstream:
-    image: bufbuild/bufstream:0.3.17
+    image: bufbuild/bufstream:0.3.20
     hostname: localhost
     container_name: bufstream
     networks:
@@ -70,6 +70,9 @@ services:
     depends_on:
       - minio
       - rest
+    environment:
+      BUFSTREAM_KAFKA_HOST: localhost
+      BUFSTREAM_KAFKA_PUBLIC_HOST: localhost
     ports:
       # We'll expose bufstream on the host at port 9092.
       - "9092:9092"
@@ -86,8 +89,6 @@ services:
     command: [
       "serve",
       "--config", "/bufstream.yaml",
-      "--config.kafka.address.host", "localhost",
-      "--config.kafka.public_address.host", "localhost",
     ]
 
   # A GUI for Bufstream's Kafka broker. See https://akhq.io


### PR DESCRIPTION
Update docker compose to use env vars instead of soon to be removed CLI flags. Update bufstream to the latest version.