### PR TITLE
Update docs for Java 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ go.work.sum
 # tmp dirs
 .tmp
 
+# Vim
+.vim
+
 
 .gradle
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ go.work.sum
 spark-warehouse
 .ipynb_checkpoints
 .Trash-*
+
+*/quickstart-java/**/bin
+*/grpc-java/**/bin

--- a/protovalidate/Makefile
+++ b/protovalidate/Makefile
@@ -10,7 +10,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
 BIN := .tmp/bin
-PROTOVALIDATE_VERSION := 0.10.3
+PROTOVALIDATE_VERSION := 0.11.1
 
 .PHONY: all
 all: clean install ci

--- a/protovalidate/grpc-java/finish/buf.yaml
+++ b/protovalidate/grpc-java/finish/buf.yaml
@@ -3,7 +3,7 @@ version: v2
 modules:
   - path: src/main/proto
 deps:
-  - buf.build/bufbuild/protovalidate:v0.10.7
+  - buf.build/bufbuild/protovalidate:v0.11.1
 lint:
   use:
     - STANDARD

--- a/protovalidate/grpc-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/finish/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.6.0"
+protovalidate = "0.8.0"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/grpc-java/finish/src/main/java/invoice/v1/InvoiceServer.java
+++ b/protovalidate/grpc-java/finish/src/main/java/invoice/v1/InvoiceServer.java
@@ -15,7 +15,6 @@
 package invoice.v1;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
-import build.buf.protovalidate.Validator;
 import build.buf.protovalidate.ValidatorFactory;
 import io.grpc.*;
 import io.grpc.protobuf.services.ProtoReflectionServiceV1;
@@ -83,7 +82,8 @@ public class InvoiceServer {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         final BindableService service = new InvoiceService();
-        final ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
+        final ValidationInterceptor interceptor =
+                new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         final ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(service, interceptor);
 
         final InvoiceServer invoiceServer =

--- a/protovalidate/grpc-java/finish/src/main/java/invoice/v1/InvoiceServer.java
+++ b/protovalidate/grpc-java/finish/src/main/java/invoice/v1/InvoiceServer.java
@@ -16,6 +16,7 @@ package invoice.v1;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
 import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
 import io.grpc.*;
 import io.grpc.protobuf.services.ProtoReflectionServiceV1;
 import java.io.IOException;
@@ -82,7 +83,7 @@ public class InvoiceServer {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         final BindableService service = new InvoiceService();
-        final ValidationInterceptor interceptor = new ValidationInterceptor(new Validator());
+        final ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         final ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(service, interceptor);
 
         final InvoiceServer invoiceServer =

--- a/protovalidate/grpc-java/finish/src/test/java/invoice/v1/InvoiceServerTest.java
+++ b/protovalidate/grpc-java/finish/src/test/java/invoice/v1/InvoiceServerTest.java
@@ -17,7 +17,6 @@ package invoice.v1;
 import static org.junit.jupiter.api.Assertions.*;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
-import build.buf.protovalidate.Validator;
 import build.buf.protovalidate.ValidatorFactory;
 import build.buf.validate.FieldPath;
 import build.buf.validate.FieldPathElement;
@@ -61,7 +60,8 @@ public class InvoiceServerTest {
 
     @BeforeAll
     public static void startServer() {
-        ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
+        ValidationInterceptor interceptor =
+                new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(new InvoiceService(), interceptor);
         server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
                 .addService(ProtoReflectionServiceV1.newInstance())

--- a/protovalidate/grpc-java/finish/src/test/java/invoice/v1/InvoiceServerTest.java
+++ b/protovalidate/grpc-java/finish/src/test/java/invoice/v1/InvoiceServerTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
 import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
 import build.buf.validate.FieldPath;
 import build.buf.validate.FieldPathElement;
 import build.buf.validate.Violation;
@@ -44,12 +45,12 @@ import org.junit.jupiter.api.*;
 
 public class InvoiceServerTest {
     private static class ViolationSpec {
-        public final String constraintId;
+        public final String ruleId;
         public final String fieldPath;
         public final String message;
 
-        public ViolationSpec(String constraintId, String fieldPath, String message) {
-            this.constraintId = constraintId;
+        public ViolationSpec(String ruleId, String fieldPath, String message) {
+            this.ruleId = ruleId;
             this.fieldPath = fieldPath;
             this.message = message;
         }
@@ -60,7 +61,7 @@ public class InvoiceServerTest {
 
     @BeforeAll
     public static void startServer() {
-        ValidationInterceptor interceptor = new ValidationInterceptor(new Validator());
+        ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(new InvoiceService(), interceptor);
         server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
                 .addService(ProtoReflectionServiceV1.newInstance())
@@ -432,9 +433,9 @@ public class InvoiceServerTest {
             Violation violation = violationList.get(i);
 
             assertEquals(
-                    violationSpec.constraintId,
-                    violation.getConstraintId(),
-                    "Expected " + violationSpec.constraintId + " but got " + violation.getConstraintId());
+                    violationSpec.ruleId,
+                    violation.getRuleId(),
+                    "Expected " + violationSpec.ruleId + " but got " + violation.getRuleId());
             assertEquals(
                     violationSpec.fieldPath,
                     fieldPathString(violation.getField()),

--- a/protovalidate/grpc-java/start/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/start/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.6.0"
+protovalidate = "0.8.0"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/grpc-java/start/src/test/java/invoice/v1/InvoiceServerTest.java
+++ b/protovalidate/grpc-java/start/src/test/java/invoice/v1/InvoiceServerTest.java
@@ -17,7 +17,6 @@ package invoice.v1;
 import static org.junit.jupiter.api.Assertions.*;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
-import build.buf.protovalidate.Validator;
 import build.buf.protovalidate.ValidatorFactory;
 import build.buf.validate.FieldPath;
 import build.buf.validate.FieldPathElement;
@@ -60,7 +59,8 @@ public class InvoiceServerTest {
 
     @BeforeAll
     public static void startServer() {
-        ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
+        ValidationInterceptor interceptor =
+                new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(new InvoiceService(), interceptor);
         server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
                 .addService(ProtoReflectionServiceV1.newInstance())

--- a/protovalidate/grpc-java/start/src/test/java/invoice/v1/InvoiceServerTest.java
+++ b/protovalidate/grpc-java/start/src/test/java/invoice/v1/InvoiceServerTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import buf.build.example.protovalidate.ValidationInterceptor;
 import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
 import build.buf.validate.FieldPath;
 import build.buf.validate.FieldPathElement;
 import build.buf.validate.Violation;
@@ -43,12 +44,12 @@ import org.junit.jupiter.api.*;
 
 public class InvoiceServerTest {
     private static class ViolationSpec {
-        public final String constraintId;
+        public final String ruleId;
         public final String fieldPath;
         public final String message;
 
-        public ViolationSpec(String constraintId, String fieldPath, String message) {
-            this.constraintId = constraintId;
+        public ViolationSpec(String ruleId, String fieldPath, String message) {
+            this.ruleId = ruleId;
             this.fieldPath = fieldPath;
             this.message = message;
         }
@@ -59,7 +60,7 @@ public class InvoiceServerTest {
 
     @BeforeAll
     public static void startServer() {
-        ValidationInterceptor interceptor = new ValidationInterceptor(new Validator());
+        ValidationInterceptor interceptor = new ValidationInterceptor(ValidatorFactory.newBuilder().build());
         ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(new InvoiceService(), interceptor);
         server = Grpc.newServerBuilderForPort(0, InsecureServerCredentials.create())
                 .addService(ProtoReflectionServiceV1.newInstance())
@@ -208,9 +209,9 @@ public class InvoiceServerTest {
             Violation violation = violationList.get(i);
 
             assertEquals(
-                    violationSpec.constraintId,
-                    violation.getConstraintId(),
-                    "Expected " + violationSpec.constraintId + " but got " + violation.getConstraintId());
+                    violationSpec.ruleId,
+                    violation.getRuleId(),
+                    "Expected " + violationSpec.ruleId + " but got " + violation.getRuleId());
             assertEquals(
                     violationSpec.fieldPath,
                     fieldPathString(violation.getField()),

--- a/protovalidate/quickstart-java/finish/buf.yaml
+++ b/protovalidate/quickstart-java/finish/buf.yaml
@@ -3,7 +3,7 @@ version: v2
 modules:
   - path: src/main/proto
 deps:
-  - buf.build/bufbuild/protovalidate:v0.10.7
+  - buf.build/bufbuild/protovalidate:v0.11.1
 lint:
   use:
     - STANDARD

--- a/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.6.0"
+protovalidate = "0.8.0"
 spotless = "7.0.2"
 
 [libraries]

--- a/protovalidate/quickstart-java/finish/src/main/java/com/bufbuild/weather/WeatherService.java
+++ b/protovalidate/quickstart-java/finish/src/main/java/com/bufbuild/weather/WeatherService.java
@@ -16,12 +16,13 @@ package com.bufbuild.weather;
 
 import build.buf.protovalidate.ValidationResult;
 import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
 import build.buf.protovalidate.exceptions.ValidationException;
 import com.bufbuild.weather.v1.GetWeatherRequest;
 
 public class WeatherService {
 
-    private static final Validator validator = new Validator();
+    private static final Validator validator = ValidatorFactory.newBuilder().build();
 
     public ValidationResult validateGetWeatherRequest(GetWeatherRequest request) throws ValidationException {
         return validator.validate(request);

--- a/protovalidate/quickstart-java/start/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/start/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.6.0"
+protovalidate = "0.8.0"
 spotless = "7.0.2"
 
 [libraries]

--- a/protovalidate/quickstart-java/start/src/main/java/com/bufbuild/weather/WeatherService.java
+++ b/protovalidate/quickstart-java/start/src/main/java/com/bufbuild/weather/WeatherService.java
@@ -16,13 +16,14 @@ package com.bufbuild.weather;
 
 import build.buf.protovalidate.ValidationResult;
 import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
 import build.buf.protovalidate.exceptions.ValidationException;
 import com.bufbuild.weather.v1.GetWeatherRequest;
 import java.util.Collections;
 
 public class WeatherService {
 
-    private static final Validator validator = new Validator();
+    private static final Validator validator = ValidatorFactory.newBuilder().build();
 
     public ValidationResult validateGetWeatherRequest(GetWeatherRequest request) throws ValidationException {
         return new ValidationResult(Collections.emptyList());


### PR DESCRIPTION
With the release of pv-java [0.8.0](https://github.com/bufbuild/protovalidate-java/releases/tag/v0.8.0), the API for creating Validators has changed. In addition, we no longer use the word `constraint` and instead use `rule` everywhere.