### PR TITLE
Fix bufstream versions

### DIFF
--- a/bufstream/iceberg-quickstart/Makefile
+++ b/bufstream/iceberg-quickstart/Makefile
@@ -9,7 +9,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
-BUFSTREAM_VERSION := 0.3.6
+BUFSTREAM_VERSION := 0.3.27
 
 .PHONY: ci
 ci: format-proto lint-proto

--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -45,3 +45,8 @@ storage:
     string: admin
   secret_access_key:
     string: password
+#iceberg:
+#  catalogs:
+#    - name: local-rest-catalog
+#      rest:
+#        url: http://iceberg-rest:8181

--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -9,9 +9,7 @@ kafka:
     host: 0.0.0.0
     port: 9092
 observability:
-  trace_exporter: NONE
-  metrics_exporter: NONE
-  log_level: DEBUG
+  log_level: INFO
   log_format: TEXT
   debug_address:
     host: 0.0.0.0

--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   # Iceberg catalog for archival. Additional configuration is in
   # config/bufstream.yaml.
   bufstream:
-    image: bufbuild/bufstream:0.3.20
+    image: bufbuild/bufstream:0.3.27
     hostname: localhost
     container_name: bufstream
     networks:


### PR DESCRIPTION
The docs were referencing the key `iceberg` in the quickstart, which was changed from `iceberg_integration` in more recent versions of Bufstream. We need to have a mechanism to make sure either (1) the quickstarts are tested when we change configuration, or more easily (2) we do tags of buf-examples and then have users check out these tags which might mean (3) we do bufstream-examples instead of buf-examples, and then tag bufstream-examples with the same release versions as bufstream.