### PR TITLE
Pinning images in Iceberg quickstart and fixing mc command

### DIFF
--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -8,7 +8,7 @@
 services:
   # Object storage: MinIO and its controller (mc)
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
     container_name: minio
     environment:
       - MINIO_ROOT_USER=admin
@@ -32,7 +32,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
     container_name: mc
     networks:
       iceberg_net:
@@ -43,7 +43,7 @@ services:
 #       /usr/bin/mc rm -r --force minio/warehouse;
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set  minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc anonymous set public minio/warehouse;
       tail -f /dev/null
@@ -54,7 +54,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: apache/iceberg-rest-fixture
+    image: apache/iceberg-rest-fixture:1.9.1
     container_name: iceberg-rest
     networks:
       iceberg_net:
@@ -143,7 +143,7 @@ services:
 
   # Spark, relying on MinIO and the REST Iceberg catalog.
   spark-iceberg:
-    image: tabulario/spark-iceberg
+    image: tabulario/spark-iceberg:3.5.5_1.8.1
     container_name: spark-iceberg
     build: spark/
     networks:

--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
-#       /usr/bin/mc rm -r --force minio/warehouse;
     entrypoint: >
       /bin/sh -c "
       until (/usr/bin/mc alias set  minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;


### PR DESCRIPTION
This PR:

* Pins versions for all images that had no pinned version
* Contains the `mc config` -> `mc alias` change