### PR TITLE
Jrinehart/tcn 2864 java quickstart gives outdated reference to

### DIFF
--- a/protovalidate/grpc-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/finish/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.10.0"
+protovalidate = "1.0.0-rc.1"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/grpc-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/finish/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.8.0"
+protovalidate = "0.10.0"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/grpc-java/start/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/start/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.10.0"
+protovalidate = "1.0.0-rc.1"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/grpc-java/start/gradle/libs.versions.toml
+++ b/protovalidate/grpc-java/start/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ annotation-api = "1.3.2"
 grpc = "1.70.0"
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.8.0"
+protovalidate = "0.10.0"
 spotless = "6.13.0"
 
 [libraries]

--- a/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.8.0"
+protovalidate = "0.10.0"
 spotless = "7.0.2"
 
 [libraries]

--- a/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/finish/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.10.0"
+protovalidate = "1.0.0-rc.1"
 spotless = "7.0.2"
 
 [libraries]

--- a/protovalidate/quickstart-java/start/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/start/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.8.0"
+protovalidate = "0.10.0"
 spotless = "7.0.2"
 
 [libraries]

--- a/protovalidate/quickstart-java/start/gradle/libs.versions.toml
+++ b/protovalidate/quickstart-java/start/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "5.12.0"
 protobuf = "4.29.3"
-protovalidate = "0.10.0"
+protovalidate = "1.0.0-rc.1"
 spotless = "7.0.2"
 
 [libraries]


### PR DESCRIPTION
As expected, nothing needed to change except the version ref. Make passes, and I've tested all Java examples in a clean clone of this repo.