### PR TITLE
Updating minio versions

### DIFF
--- a/bufstream/docker-compose/docker-compose.yml
+++ b/bufstream/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   # MinIO provides local S3-compatible object storage.
   minio:
-    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     network_mode: host
     volumes: ["./minio:/data"]
     healthcheck:
@@ -23,7 +23,7 @@ services:
 
   # Minio Client (https://min.io/docs/minio/linux/reference/minio-mc.html) bootstraps a MinIO bucket.
   mc:
-    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    image: minio/mc:RELEASE.2025-07-21T05-28-08Z
     depends_on:
       minio: { "condition": "service_healthy" }
     network_mode: host


### PR DESCRIPTION
I was verifying this today and figured I'd update the versions of minio to get rid of its warnings in the console. I've verified by removing my volume directories and checking that they're re-created and Bufstream starts:

```
bufstream-1  | {"time":"2025-08-14T14:14:57.445840137Z","level":"INFO","msg":"kafka server started","host":"::1","port":9092,"tls":false}
bufstream-1  | {"time":"2025-08-14T14:14:57.47118647Z","level":"INFO","msg":"updating ownership","oldShardNum":0,"oldShardCount":0,"shardNum":0,"shardCount":1}
```