### PR TITLE
Update Iceberg quickstart to v0.3.44

### DIFF
--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -36,8 +36,8 @@ storage:
     string: admin
   secret_access_key:
     string: password
-iceberg:
-  catalogs:
-    - name: local-rest-catalog
-      rest:
-        url: http://iceberg-rest:8181
+#iceberg:
+#  catalogs:
+#    - name: local-rest-catalog
+#      rest:
+#        url: http://iceberg-rest:8181

--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -26,13 +26,6 @@ data_enforcement:
         on_parse_error: REJECT_BATCH
         validation:
           on_error: REJECT_BATCH
-  fetch:
-    - topics: { all: true }
-      schema_registry: csr
-      values:
-        on_parse_error: FILTER_RECORD
-        redaction:
-          debug_redact: true
 
 storage:
   provider: S3
@@ -43,8 +36,8 @@ storage:
     string: admin
   secret_access_key:
     string: password
-#iceberg:
-#  catalogs:
-#    - name: local-rest-catalog
-#      rest:
-#        url: http://iceberg-rest:8181
+iceberg:
+  catalogs:
+    - name: local-rest-catalog
+      rest:
+        url: http://iceberg-rest:8181

--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   # Iceberg catalog for archival. Additional configuration is in
   # config/bufstream.yaml.
   bufstream:
-    image: bufbuild/bufstream:0.3.42
+    image: bufbuild/bufstream:0.3.44
     hostname: localhost
     container_name: bufstream
     networks:

--- a/protovalidate/bufstream/start/go.sum
+++ b/protovalidate/bufstream/start/go.sum
@@ -1,6 +1,5 @@
 buf.build/gen/go/bufbuild/confluent/protocolbuffers/go v1.36.5-20240926213411-65369e65bbcd.1 h1:dTC+aETctWAT9unYWXI/IsGwD7YdaNwT7JPlCjc47IU=
 buf.build/gen/go/bufbuild/confluent/protocolbuffers/go v1.36.5-20240926213411-65369e65bbcd.1/go.mod h1:ZufkzpEmQ7tsrN8FBmSxpX+j70PK8LIPf2S0c6rLdS4=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.115.1 h1:Jo0SM9cQnSkYfp44+v+NQXHpcHqlnRJk2qxh6yvxxxQ=

--- a/protovalidate/bufstream/start/go.sum
+++ b/protovalidate/bufstream/start/go.sum
@@ -1,5 +1,6 @@
 buf.build/gen/go/bufbuild/confluent/protocolbuffers/go v1.36.5-20240926213411-65369e65bbcd.1 h1:dTC+aETctWAT9unYWXI/IsGwD7YdaNwT7JPlCjc47IU=
 buf.build/gen/go/bufbuild/confluent/protocolbuffers/go v1.36.5-20240926213411-65369e65bbcd.1/go.mod h1:ZufkzpEmQ7tsrN8FBmSxpX+j70PK8LIPf2S0c6rLdS4=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.115.1 h1:Jo0SM9cQnSkYfp44+v+NQXHpcHqlnRJk2qxh6yvxxxQ=


### PR DESCRIPTION
* Updates version used
* Removes now-invalid configuration options

If reviewing, it's imperative to test this quickstart against the updated docs in the corresponding docs PR.