### PR TITLE
Commenting out Iceberg config in quickstart

### DIFF
--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -12,7 +12,7 @@ data:
       string: admin
     secret_access_key:
       string: password
-iceberg:
-  - name: local-rest-catalog
-    rest:
-      url: http://iceberg-rest:8181
+# iceberg:
+#   - name: local-rest-catalog
+#     rest:
+#       url: http://iceberg-rest:8181


### PR DESCRIPTION
[The docs](https://buf.build/docs/bufstream/iceberg/quickstart/#configure-bufstream-for-iceberg) mention this being commented out, but I accidentally left it in place when I did the 0.4.0 update.