### PR TITLE
Update to golangci v2 configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Buf CLI
         run: go install github.com/bufbuild/buf/cmd/buf@v1.50.0
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       - name: Install Python

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,47 +1,64 @@
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  forbidigo:
-    forbid:
-      - '^fmt\.Print'
-      - '^log\.'
-      - '^print$'
-      - '^println$'
-      - '^panic$'
-  godox:
-    # Use "fix me" comments for temporary hacks, and use godox to prevent
-    # committing them.
-    keywords: [FIXME]
-  varnamelen:
-    ignore-decls:
-      - T any
-      - i int
-      - wg sync.WaitGroup
-      - ok bool
-      - w io.Writer
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - cyclop            # covered by gocyclo
-    - depguard          # we can manage dependencies strictly if the need arises in the future
-    - err113            # internal error causes may be dynamic
-    - exhaustruct       # don't _always_ need to exhaustively create struct
-    - funlen            # rely on code review to limit function length
-    - gocognit          # dubious "cognitive overhead" quantification
-    - gofumpt           # prefer standard gofmt
-    - goimports         # rely on gci instead
-    - gomoddirectives   # we use go modules replacements intentionally
-    - gomodguard        # not compatible with go workspaces
-    - intrange          # enable once go 1.22 is baseline
-    - ireturn           # "accept interfaces, return structs" isn't ironclad
-    - lll               # don't want hard limits for line length
-    - maintidx          # covered by gocyclo
-    - mnd               # some unnamed constants are okay
-    - nlreturn          # generous whitespace violates house style
-    - nonamedreturns    # usage of named returns should be selective
-    - testpackage       # internal tests are fine
-    - tenv              # deprecated, replaced by usetesting
-    - wrapcheck         # don't _always_ need to wrap errors
-    - wsl               # over-generous whitespace violates house style
-issues:
-  exclude-use-default: true
+    - cyclop
+    - noinlineerr
+    - depguard
+    - err113
+    - exhaustruct
+    - funlen
+    - gocognit
+    - gomoddirectives
+    - gomodguard
+    - intrange
+    - ireturn
+    - lll
+    - maintidx
+    - mnd
+    - nlreturn
+    - nonamedreturns
+    - testpackage
+    - wrapcheck
+    - wsl
+  settings:
+    errcheck:
+      check-type-assertions: true
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print
+        - pattern: ^log\.
+        - pattern: ^print$
+        - pattern: ^println$
+        - pattern: ^panic$
+    godox:
+      keywords:
+        - FIXME
+    varnamelen:
+      ignore-decls:
+        - T any
+        - i int
+        - wg sync.WaitGroup
+        - ok bool
+        - w io.Writer
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/protovalidate/connect-go/finish/cmd/server.go
+++ b/protovalidate/connect-go/finish/cmd/server.go
@@ -38,6 +38,7 @@ func main() {
 		slog.Error("error creating interceptor",
 			slog.String("error", err.Error()),
 		)
+
 		return
 	}
 

--- a/protovalidate/connect-go/finish/internal/invoice/invoice_test.go
+++ b/protovalidate/connect-go/finish/internal/invoice/invoice_test.go
@@ -181,6 +181,7 @@ func TestCreateInvoice(t *testing.T) {
 			producer: func(invoice *invoicev1.Invoice) *invoicev1.Invoice {
 				invoice.GetLineItems()[0].ProductId = invoice.GetLineItems()[1].GetProductId()
 				invoice.GetLineItems()[0].UnitPrice = invoice.GetLineItems()[1].GetUnitPrice()
+
 				return invoice
 			},
 			violations: []violationSpec{
@@ -303,6 +304,7 @@ func TestCreateInvoice(t *testing.T) {
 			// our expected violations.
 			if len(testCase.violations) > 0 {
 				require.Error(t, err)
+
 				var connectError *connect.Error
 				require.ErrorAs(t, err, &connectError)
 				assert.Equal(t, connect.CodeInvalidArgument, connectError.Code())
@@ -366,6 +368,7 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 	if len(details) != 1 {
 		t.Errorf("Connect error had %d details instead of one", len(details))
 	}
+
 	detail, err := details[0].Value()
 	if err != nil {
 		t.Errorf("Couldn't get value of first error detail: %v", err)
@@ -385,6 +388,7 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 		if len(allViolations) != len(specs) {
 			t.Fatalf("violations returned %d violations instead of %d", len(allViolations), len(specs))
 		}
+
 		for i, spec := range specs {
 			violation := allViolations[i]
 
@@ -392,10 +396,12 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 			if violation.GetRuleId() != spec.ruleID {
 				t.Fatalf("Wrong ruleID. Expected \"%v\", not \"%v\"", spec.ruleID, violation.GetRuleId())
 			}
+
 			fieldPath := protovalidate.FieldPathString(violation.GetField())
 			if fieldPath != spec.fieldPath {
 				t.Fatalf("Wrong fieldPath. Expected \"%v\", not \"%v\"", spec.fieldPath, fieldPath)
 			}
+
 			if violation.GetMessage() != spec.message {
 				t.Fatalf("Wrong message. Expected \"%v\", not \"%v\"", spec.message, violation.GetMessage())
 			}
@@ -409,9 +415,11 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 // registers it for closing within cleanup.
 func startHTTPServer(tb testing.TB, h http.Handler) *httptest.Server {
 	tb.Helper()
+
 	srv := httptest.NewUnstartedServer(h)
 	srv.EnableHTTP2 = true
 	srv.Start()
 	tb.Cleanup(srv.Close)
+
 	return srv
 }

--- a/protovalidate/connect-go/start/internal/invoice/invoice_test.go
+++ b/protovalidate/connect-go/start/internal/invoice/invoice_test.go
@@ -91,6 +91,7 @@ func TestCreateInvoice(t *testing.T) {
 			producer: func(invoice *invoicev1.Invoice) *invoicev1.Invoice {
 				invoice.GetLineItems()[0].ProductId = invoice.GetLineItems()[1].GetProductId()
 				invoice.GetLineItems()[0].UnitPrice = invoice.GetLineItems()[1].GetUnitPrice()
+
 				return invoice
 			},
 			violations: []violationSpec{
@@ -123,6 +124,7 @@ func TestCreateInvoice(t *testing.T) {
 			// our expected violations.
 			if len(testCase.violations) > 0 {
 				require.Error(t, err)
+
 				var connectError *connect.Error
 				require.ErrorAs(t, err, &connectError)
 				assert.Equal(t, connect.CodeInvalidArgument, connectError.Code())
@@ -186,6 +188,7 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 	if len(details) != 1 {
 		t.Errorf("Connect error had %d details instead of one", len(details))
 	}
+
 	detail, err := details[0].Value()
 	if err != nil {
 		t.Errorf("Couldn't get value of first error detail: %v", err)
@@ -205,6 +208,7 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 		if len(allViolations) != len(specs) {
 			t.Fatalf("violations returned %d violations instead of %d", len(allViolations), len(specs))
 		}
+
 		for i, spec := range specs {
 			violation := allViolations[i]
 
@@ -212,10 +216,12 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 			if violation.GetRuleId() != spec.ruleID {
 				t.Fatalf("Wrong ruleID. Expected \"%v\", not \"%v\"", spec.ruleID, violation.GetRuleId())
 			}
+
 			fieldPath := protovalidate.FieldPathString(violation.GetField())
 			if fieldPath != spec.fieldPath {
 				t.Fatalf("Wrong fieldPath. Expected \"%v\", not \"%v\"", spec.fieldPath, fieldPath)
 			}
+
 			if violation.GetMessage() != spec.message {
 				t.Fatalf("Wrong message. Expected \"%v\", not \"%v\"", spec.message, violation.GetMessage())
 			}
@@ -229,9 +235,11 @@ func checkConnectError(t *testing.T, connectError *connect.Error, specs []violat
 // registers it for closing within cleanup.
 func startHTTPServer(tb testing.TB, h http.Handler) *httptest.Server {
 	tb.Helper()
+
 	srv := httptest.NewUnstartedServer(h)
 	srv.EnableHTTP2 = true
 	srv.Start()
 	tb.Cleanup(srv.Close)
+
 	return srv
 }

--- a/protovalidate/grpc-go/finish/cmd/server.go
+++ b/protovalidate/grpc-go/finish/cmd/server.go
@@ -63,7 +63,9 @@ func run(ctx context.Context) error {
 	errorGroup.Go(func() error {
 		address := "localhost:50051"
 
-		lis, err := net.Listen("tcp", address)
+		config := net.ListenConfig{}
+
+		lis, err := config.Listen(ctx, "tcp", address)
 		if err != nil {
 			return fmt.Errorf("failed to listen on address %q: %w", address, err)
 		}

--- a/protovalidate/grpc-go/finish/internal/invoice_test.go
+++ b/protovalidate/grpc-go/finish/internal/invoice_test.go
@@ -71,12 +71,14 @@ func TestCreateInvoice(t *testing.T) {
 
 	// Create a client shared by all of our test cases.
 	resolver.SetDefaultScheme("passthrough")
+
 	conn, err := grpc.NewClient("bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
+
 	invoiceServiceClient := invoicev1.NewInvoiceServiceClient(conn)
 
 	testCases := map[string]struct {
@@ -195,6 +197,7 @@ func TestCreateInvoice(t *testing.T) {
 			producer: func(invoice *invoicev1.Invoice) *invoicev1.Invoice {
 				invoice.GetLineItems()[0].ProductId = invoice.GetLineItems()[1].GetProductId()
 				invoice.GetLineItems()[0].UnitPrice = invoice.GetLineItems()[1].GetUnitPrice()
+
 				return invoice
 			},
 			violations: []violationSpec{
@@ -376,6 +379,7 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 	if len(details) != 1 {
 		t.Errorf("Status error had %d details instead of one", len(details))
 	}
+
 	detail := details[0]
 	switch violations := detail.(type) {
 	case *validate.Violations:
@@ -387,6 +391,7 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 		if len(allViolations) != len(specs) {
 			t.Fatalf("violations returned %d violations instead of %d", len(allViolations), len(specs))
 		}
+
 		for i, spec := range specs {
 			violation := allViolations[i]
 
@@ -394,10 +399,12 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 			if violation.GetRuleId() != spec.ruleID {
 				t.Fatalf("Wrong ruleID. Expected \"%v\", not \"%v\"", spec.ruleID, violation.GetRuleId())
 			}
+
 			fieldPath := protovalidate.FieldPathString(violation.GetField())
 			if fieldPath != spec.fieldPath {
 				t.Fatalf("Wrong fieldPath. Expected \"%v\", not \"%v\"", spec.fieldPath, fieldPath)
 			}
+
 			if violation.GetMessage() != spec.message {
 				t.Fatalf("Wrong message. Expected \"%v\", not \"%v\"", spec.message, violation.GetMessage())
 			}

--- a/protovalidate/grpc-go/start/cmd/server.go
+++ b/protovalidate/grpc-go/start/cmd/server.go
@@ -54,7 +54,9 @@ func run(ctx context.Context) error {
 	errorGroup.Go(func() error {
 		address := "localhost:50051"
 
-		lis, err := net.Listen("tcp", address)
+		config := net.ListenConfig{}
+
+		lis, err := config.Listen(ctx, "tcp", address)
 		if err != nil {
 			return fmt.Errorf("failed to listen on address %q: %w", address, err)
 		}

--- a/protovalidate/grpc-go/start/internal/invoice_test.go
+++ b/protovalidate/grpc-go/start/internal/invoice_test.go
@@ -71,12 +71,14 @@ func TestCreateInvoice(t *testing.T) {
 
 	// Create a client shared by all of our test cases.
 	resolver.SetDefaultScheme("passthrough")
+
 	conn, err := grpc.NewClient("bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
+
 	invoiceServiceClient := invoicev1.NewInvoiceServiceClient(conn)
 
 	testCases := map[string]struct {
@@ -105,6 +107,7 @@ func TestCreateInvoice(t *testing.T) {
 			producer: func(invoice *invoicev1.Invoice) *invoicev1.Invoice {
 				invoice.GetLineItems()[0].ProductId = invoice.GetLineItems()[1].GetProductId()
 				invoice.GetLineItems()[0].UnitPrice = invoice.GetLineItems()[1].GetUnitPrice()
+
 				return invoice
 			},
 			violations: []violationSpec{
@@ -196,6 +199,7 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 	if len(details) != 1 {
 		t.Errorf("Status error had %d details instead of one", len(details))
 	}
+
 	detail := details[0]
 	switch violations := detail.(type) {
 	case *validate.Violations:
@@ -207,6 +211,7 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 		if len(allViolations) != len(specs) {
 			t.Fatalf("violations returned %d violations instead of %d", len(allViolations), len(specs))
 		}
+
 		for i, spec := range specs {
 			violation := allViolations[i]
 
@@ -214,10 +219,12 @@ func checkStatusError(t *testing.T, responseStatus *status.Status, specs []viola
 			if violation.GetRuleId() != spec.ruleID {
 				t.Fatalf("Wrong ruleID. Expected \"%v\", not \"%v\"", spec.ruleID, violation.GetRuleId())
 			}
+
 			fieldPath := protovalidate.FieldPathString(violation.GetField())
 			if fieldPath != spec.fieldPath {
 				t.Fatalf("Wrong fieldPath. Expected \"%v\", not \"%v\"", spec.fieldPath, fieldPath)
 			}
+
 			if violation.GetMessage() != spec.message {
 				t.Fatalf("Wrong message. Expected \"%v\", not \"%v\"", spec.message, violation.GetMessage())
 			}

--- a/protovalidate/quickstart-go/finish/weather/weather_test.go
+++ b/protovalidate/quickstart-go/finish/weather/weather_test.go
@@ -75,10 +75,11 @@ func TestRequests(t *testing.T) {
 
 			if len(testCase.violations) > 0 {
 				require.Error(t, err)
+
 				var validationError *protovalidate.ValidationError
 				require.ErrorAs(t, err, &validationError)
-
 				require.Len(t, validationError.Violations, len(testCase.violations))
+
 				for i, violation := range testCase.violations {
 					assert.Equal(t, violation, validationError.Violations[i].Proto.GetMessage())
 				}

--- a/protovalidate/quickstart-go/start/weather/weather_test.go
+++ b/protovalidate/quickstart-go/start/weather/weather_test.go
@@ -75,10 +75,11 @@ func TestRequests(t *testing.T) {
 
 			if len(testCase.violations) > 0 {
 				require.Error(t, err)
+
 				var validationError *protovalidate.ValidationError
 				require.ErrorAs(t, err, &validationError)
-
 				require.Len(t, validationError.Violations, len(testCase.violations))
+
 				for i, violation := range testCase.violations {
 					assert.Equal(t, violation, validationError.Violations[i].Proto.GetMessage())
 				}

--- a/protovalidate/rules-predefined/finish/internal/bufbuild/people/v1/person_test.go
+++ b/protovalidate/rules-predefined/finish/internal/bufbuild/people/v1/person_test.go
@@ -100,6 +100,7 @@ func TestPersonValidation(t *testing.T) {
 			if err != nil && testCase.valid {
 				t.Fatalf("unexpected validation error received: %v", err)
 			}
+
 			if err == nil && !testCase.valid {
 				t.Fatal("expected validation error")
 			}

--- a/protovalidate/rules-predefined/start/internal/bufbuild/people/v1/person_test.go
+++ b/protovalidate/rules-predefined/start/internal/bufbuild/people/v1/person_test.go
@@ -94,6 +94,7 @@ func TestPersonValidation(t *testing.T) {
 			if err != nil && testCase.valid {
 				t.Fatalf("unexpected validation error received: %v", err)
 			}
+
 			if err == nil && !testCase.valid {
 				t.Fatal("expected validation error")
 			}


### PR DESCRIPTION
This PR updates this repo to use golangci version 2 configuration files. 

1. The config file (.golangci.yml) changes have been generated by their upgrade tool.
2. All other changes are just lint fixes. 
    1. All but one are whitespace issues. 
    2. The remaining is a recommended shift to using `(*net.ListenerConfig).Listen` instead of `net.Listen`.